### PR TITLE
Chat command prefixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         type: "zip"
         filename: "CrowControl.zip"
         exclusions: "/third-party/* /Source/* /lib-stripped/* *.git* *.sln *.md .everestignore *.zip"
-    - name: Make Draft Release
+    - name: Make Release
       if: startsWith(github.ref, 'refs/tags/')
       uses: ncipollo/release-action@v1
       with:

--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ This is the same as original CrowControl with the following fixes:
 
 * Update version.
 * Update to the current API/SDK.
-* Update plugin layout layout.
+* Update plugin layout.
 * Requests properly count up.
 * Option: Commands can require unique user, allowing you to prevent the scenario of one user be able to spam `!die` a bunch of times.
 * Option: Spawned enemy AI is cleaned up properly on death.
+* Option: Chat commands can require an `!` or not. Does not apply to bits or channel point redemptions.
+  * When this is on, matches are only done if the command is the first thing in the message.
 * Fix `!die` to work properly when already dead.
 * Exit the application cleanly, when connected.
 * Fix high CPU usage (because of inf. loop).

--- a/Source/CrowControlSettings.cs
+++ b/Source/CrowControlSettings.cs
@@ -25,6 +25,7 @@ namespace Celeste.Mod.CrowControl
         [SettingName(DialogIds.RequireUniqueUsers)] public bool RequireUniqueUsers { get; set; } = false;
         [SettingName(DialogIds.ClearSpawnsOnDeath)] public bool ClearSpawnsOnDeath { get; set; } = true;
         [SettingName(DialogIds.ReconnectOnDisconnect)] public bool ReconnectOnDisconnect { get; set; } = true;
+        [SettingName(DialogIds.RequireChatCommandPrefix)] public bool RequireCommandPrefixOnChat { get; set; } = false;
         [SettingName(DialogIds.ChannelName)] public string ChannelName { get; set; } = "";
         [SettingName(DialogIds.Connect)] public string Connect { get; set; } = "";
         [SettingName(DialogIds.Disconnect)] public string Disconnect { get; set; } = "";
@@ -132,16 +133,16 @@ namespace Celeste.Mod.CrowControl
         private Random rand = new Random();
 
         // better handle socket disconnections
-        public bool IsExiting = false;
-        private CancellationTokenSource cancelToken;
-        private bool clickedDisconnect = false;
+        [YamlIgnore] public bool IsExiting = false;
+        [YamlIgnore] private CancellationTokenSource cancelToken;
+        [YamlIgnore] private bool clickedDisconnect = false;
 
         [YamlIgnore] public Dictionary<MessageType, List<string>> currentVoteCounts = new Dictionary<MessageType, List<string>>();
 
         public CrowControlSettings() 
         {
             int randNum = rand.Next(10000, 99999);
-            TwitchUsername += randNum;
+            TwitchUsername += randNum.ToString();
 
             // Dynamically populate the dictionary.
             var MsgEnumVals = Enum.GetValues(typeof(MessageType)).Cast<MessageType>();
@@ -297,7 +298,7 @@ namespace Celeste.Mod.CrowControl
         {
             IrcParser parser = new IrcParser();
             IrcMessage msg = parser.ParseIrcMessage(e.Data);
-            ChatMessage chatMsg = new ChatMessage(TwitchUsername, msg);
+            ChatMessage chatMsg = new ChatMessage(TwitchUsername, msg, RequireCommandPrefixOnChat);
 
             if (msg.Command == IrcCommand.Ping) 
             {

--- a/Source/DialogIds.cs
+++ b/Source/DialogIds.cs
@@ -16,6 +16,7 @@
         public const string Enabled = "CROWCONTROL_ENABLED";
         public const string ChannelName = "CROWCONTROL_CHANNELNAME";
         public const string ReconnectOnDisconnect = "RECONNECT_ON_DISCONNECT";
+        public const string RequireChatCommandPrefix = "REQUIRE_CHAT_COMMAND_PREFIX";
         public const string Connect = "CROWCONTROL_CONNECT";
         public const string Disconnect = "CROWCONTROL_DISCONNECT";
 

--- a/everest.yaml
+++ b/everest.yaml
@@ -3,7 +3,7 @@
   DLL: bin/websocket-sharp.dll
       
 - Name: CrowControl
-  Version: 1.1.1
+  Version: 1.1.2
   DLL: bin/CrowControl.dll
   Dependencies:
     - Name: EverestCore


### PR DESCRIPTION
This change allows for actions to only count if they have the standard twitch chat command prefix of `!`, this doesn't apply for channel point rewards nor bit redemption.

Binaries can be found https://github.com/SocksTheWolf/CrowControl/releases/tag/v1.1.2